### PR TITLE
Update BounceLogsTable.php

### DIFF
--- a/src/Model/Table/BounceLogsTable.php
+++ b/src/Model/Table/BounceLogsTable.php
@@ -107,7 +107,7 @@ class BounceLogsTable extends Table
                     $this->Users->updateFields($targetEmail);
                 }
             } catch (\Exception $e) {
-                Log::write(LOG_ERR, $e->getTraceAsString());
+                Log::write(LOG_WARNING, $e->getTraceAsString());
                 return false;
             }
             return true;


### PR DESCRIPTION
メールアドレスの検索に失敗した場合、ErrorではなくWarningとしてerror.logに出力する
