### PR TITLE
ユーザーIDが作成されない場合もある為、bounce_logsのtarget_idのnullをokしメアドを保管するように変更

### DIFF
--- a/config/Migrations/20161125120000_AddMailColumn.php
+++ b/config/Migrations/20161125120000_AddMailColumn.php
@@ -1,0 +1,47 @@
+<?php
+use Migrations\AbstractMigration;
+use Phinx\Db\Table;
+
+class AddMailColumn extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function up()
+    {
+        /** @var Table $table */
+        $table = $this->table('bounce_logs');
+        $table->changeColumn("target_id", 'integer', [
+            'signed' => false,
+            'null' => true,
+        ])
+        ->addColumn("mail", 'string', [
+            'default' => null,
+            'limit' => 255,
+            'null' => false,
+            'after' => 'target_id',
+        ])
+        ->addIndex(
+            [
+                'mail'
+            ]
+        )
+        ->update();
+    }
+
+    public function down()
+    {
+        /** @var Table $table */
+        $table = $this->table('bounce_logs');
+        $table->changeColumn("target_id", 'integer', [
+            'signed' => false,
+            'null' => false,
+        ])
+        ->removeColumn("mail")
+        ->update();
+    }
+}

--- a/src/Model/Table/BounceLogsTable.php
+++ b/src/Model/Table/BounceLogsTable.php
@@ -88,23 +88,23 @@ class BounceLogsTable extends Table
 
                 /** @var BounceLog $bounceLogs */
                 $bounceLogs = $this->newEntity([
-                    "target_id" => $key,
+                    'target_id' => $key,
+                    'mail' => $targetEmail,
                     'message' => $message['Message'],
                 ]);
-
                 if ($bounceLogs->errors()) {
                     throw new \Exception('Error: Failed insertLog(). %s = %d');
                 }
-
                 $this->save($bounceLogs, ['atomic' => false]);
 
                 // Update mail sending setting
-                $count = $this->find()
-                    ->where(["target_id" => $key])
-                    ->count();
-
-                if ($settings['stopSending'] && $count > $settings['bounceLimit']) {
-                    $this->Users->updateFields($targetEmail);
+                if ($settings['stopSending'] && !empty($key)) {
+                    $count = $this->find()
+                        ->where(["target_id" => $key])
+                        ->count();
+                    if ($count > $settings['bounceLimit']) {
+                        $this->Users->updateFields($key);
+                    }
                 }
             } catch (\Exception $e) {
                 Log::write(LOG_WARNING, $e->getTraceAsString());

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -63,21 +63,23 @@ class UsersTable extends Table
         }
 
         $key = $this->find()
-            ->where([$setting['mailField'] => $email])
-            ->firstOrFail()
+            ->where([
+                $setting['mailField'] => $email,
+                $setting['key'] . " is not null"
+            ])
+            ->first()
             ->{$setting['key']};
 
         return $key;
     }
 
     /**
-     * @param $email
+     * @param $key
      * @return bool|\Cake\Datasource\EntityInterface|mixed
      * @throws RecordNotFoundException|\Exception
      */
-    public function updateFields($email)
+    public function updateFields($key)
     {
-        $key = $this->getKeyByEmail($email);
         $Model = TableRegistry::get($this->config['settings']['updateFields']['model']);
 
         $entity = $Model->get($key);


### PR DESCRIPTION
@hampom 
bounce_logsにメールアドレスを保管するようにして、target_idがない場合も登録できるようにしました(´･ω･`)